### PR TITLE
Refactoring of class structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.dapete</groupId>
     <artifactId>locks</artifactId>
-    <version>1.2.2-SNAPSHOT</version>
+    <version>1.3.0-SNAPSHOT</version>
 
     <name>locks</name>
     <description>Library for key-based locking</description>

--- a/src/main/java/net/dapete/locks/AbstractLocks.java
+++ b/src/main/java/net/dapete/locks/AbstractLocks.java
@@ -41,7 +41,7 @@ abstract class AbstractLocks<K, L> {
      * @param key key
      * @return lock
      */
-    public L get(K key) {
+    public final L get(K key) {
         processQueue();
         instanceLock.lock();
         try {
@@ -58,9 +58,9 @@ abstract class AbstractLocks<K, L> {
         }
     }
 
-    // package-private to allow accessing this in tests
+    // protected to allow accessing this in tests
     @Nullable
-    LockReference<K, L> getLockReference(K key) {
+    protected final LockReference<K, L> getLockReference(K key) {
         return lockReferenceMap.get(key);
     }
 
@@ -69,7 +69,7 @@ abstract class AbstractLocks<K, L> {
      *
      * @return number of locks
      */
-    public int size() {
+    public final int size() {
         processQueue();
         instanceLock.lock();
         try {

--- a/src/main/java/net/dapete/locks/LockReference.java
+++ b/src/main/java/net/dapete/locks/LockReference.java
@@ -3,7 +3,7 @@ package net.dapete.locks;
 import java.lang.ref.ReferenceQueue;
 import java.lang.ref.WeakReference;
 
-class LockReference<K, L> extends WeakReference<L> {
+final class LockReference<K, L> extends WeakReference<L> {
 
     private final K key;
 

--- a/src/main/java/net/dapete/locks/Locks.java
+++ b/src/main/java/net/dapete/locks/Locks.java
@@ -10,11 +10,7 @@ import java.util.function.Supplier;
  * @param <K> type of key
  * @param <L> type of {@link Lock}
  */
-public class Locks<K, L extends Lock> extends AbstractLocks<K, L> {
-
-    Locks(Supplier<L> lockSupplier) {
-        super(lockSupplier);
-    }
+public interface Locks<K, L extends Lock> {
 
     /**
      * Return an instance using {@link Lock} implementations created by the specified {@code lockSupplier}.
@@ -24,8 +20,8 @@ public class Locks<K, L extends Lock> extends AbstractLocks<K, L> {
      * @param <L>          type of {@link Lock}
      * @return instance using {@code Lock} implementations created by the specified {@code lockSupplier}
      */
-    public static <K, L extends Lock> Locks<K, L> withSupplier(Supplier<L> lockSupplier) {
-        return new Locks<>(lockSupplier);
+    static <K, L extends Lock> Locks<K, L> withSupplier(Supplier<L> lockSupplier) {
+        return new LocksImpl<>(lockSupplier);
     }
 
     /**
@@ -34,7 +30,7 @@ public class Locks<K, L extends Lock> extends AbstractLocks<K, L> {
      * @param <K> type of key
      * @return {@code ReentrantLocks} instance
      */
-    public static <K> ReentrantLocks<K> reentrant() {
+    static <K> ReentrantLocks<K> reentrant() {
         return new ReentrantLocks<>();
     }
 
@@ -45,7 +41,7 @@ public class Locks<K, L extends Lock> extends AbstractLocks<K, L> {
      * @param <K>      type of key
      * @return {@code ReentrantLocks} instance
      */
-    public static <K> ReentrantLocks<K> reentrant(@SuppressWarnings("unused") Class<K> keyClass) {
+    static <K> ReentrantLocks<K> reentrant(@SuppressWarnings("unused") Class<K> keyClass) {
         return reentrant();
     }
 
@@ -57,7 +53,7 @@ public class Locks<K, L extends Lock> extends AbstractLocks<K, L> {
      * @return {@code ReentrantLocks} instance
      * @since 1.2.0
      */
-    public static <K> ReentrantLocks<K> reentrant(boolean fair) {
+    static <K> ReentrantLocks<K> reentrant(boolean fair) {
         return new ReentrantLocks<>(fair);
     }
 
@@ -70,9 +66,17 @@ public class Locks<K, L extends Lock> extends AbstractLocks<K, L> {
      * @return {@code ReentrantLocks} instance
      * @since 1.2.0
      */
-    public static <K> ReentrantLocks<K> reentrant(boolean fair, @SuppressWarnings("unused") Class<K> keyClass) {
+    static <K> ReentrantLocks<K> reentrant(boolean fair, @SuppressWarnings("unused") Class<K> keyClass) {
         return reentrant(fair);
     }
+
+    /**
+     * Returns a lock for the supplied key. There will be at most one lock per key at any given time.
+     *
+     * @param key key
+     * @return lock
+     */
+    L get(K key);
 
     /**
      * Return a {@code Lock} already locked using {@link Lock#lock()}.
@@ -80,10 +84,13 @@ public class Locks<K, L extends Lock> extends AbstractLocks<K, L> {
      * @param key key
      * @return already locked lock
      */
-    public L lock(K key) {
-        final var lock = get(key);
-        lock.lock();
-        return lock;
-    }
+    L lock(K key);
+
+    /**
+     * Returns the current number of locks managed by this instance.
+     *
+     * @return number of locks
+     */
+    int size();
 
 }

--- a/src/main/java/net/dapete/locks/LocksImpl.java
+++ b/src/main/java/net/dapete/locks/LocksImpl.java
@@ -1,0 +1,19 @@
+package net.dapete.locks;
+
+import java.util.concurrent.locks.Lock;
+import java.util.function.Supplier;
+
+class LocksImpl<K, L extends Lock> extends AbstractLocks<K, L> implements Locks<K, L> {
+
+    LocksImpl(Supplier<L> lockSupplier) {
+        super(lockSupplier);
+    }
+
+    @Override
+    public L lock(K key) {
+        final var lock = get(key);
+        lock.lock();
+        return lock;
+    }
+
+}

--- a/src/main/java/net/dapete/locks/LocksImpl.java
+++ b/src/main/java/net/dapete/locks/LocksImpl.java
@@ -10,7 +10,7 @@ class LocksImpl<K, L extends Lock> extends AbstractLocks<K, L> implements Locks<
     }
 
     @Override
-    public L lock(K key) {
+    public final L lock(K key) {
         final var lock = get(key);
         lock.lock();
         return lock;

--- a/src/main/java/net/dapete/locks/ReadWriteLocks.java
+++ b/src/main/java/net/dapete/locks/ReadWriteLocks.java
@@ -11,11 +11,7 @@ import java.util.function.Supplier;
  * @param <K> type of key
  * @param <L> type of ReadWriteLock
  */
-public class ReadWriteLocks<K, L extends ReadWriteLock> extends AbstractLocks<K, L> {
-
-    ReadWriteLocks(Supplier<L> lockSupplier) {
-        super(lockSupplier);
-    }
+public interface ReadWriteLocks<K, L extends ReadWriteLock> {
 
     /**
      * Return an instance using {@link ReadWriteLock} implementations created by the specified {@code lockSupplier}.
@@ -25,8 +21,8 @@ public class ReadWriteLocks<K, L extends ReadWriteLock> extends AbstractLocks<K,
      * @param <L>          type of {@link Lock}
      * @return instance using {@code ReadWriteLock} implementations created by the specified {@code lockSupplier}
      */
-    public static <K, L extends ReadWriteLock> ReadWriteLocks<K, L> withSupplier(Supplier<L> lockSupplier) {
-        return new ReadWriteLocks<>(lockSupplier);
+    static <K, L extends ReadWriteLock> ReadWriteLocks<K, L> withSupplier(Supplier<L> lockSupplier) {
+        return new ReadWriteLocksImpl<>(lockSupplier);
     }
 
     /**
@@ -35,7 +31,7 @@ public class ReadWriteLocks<K, L extends ReadWriteLock> extends AbstractLocks<K,
      * @param <K> type of key
      * @return {@code ReentrantReadWriteLocks} instance
      */
-    public static <K> ReentrantReadWriteLocks<K> reentrant() {
+    static <K> ReentrantReadWriteLocks<K> reentrant() {
         return new ReentrantReadWriteLocks<>();
     }
 
@@ -46,7 +42,7 @@ public class ReadWriteLocks<K, L extends ReadWriteLock> extends AbstractLocks<K,
      * @param <K>      type of key
      * @return {@code ReentrantReadWriteLocks} instance
      */
-    public static <K> ReentrantReadWriteLocks<K> reentrant(@SuppressWarnings("unused") Class<K> keyClass) {
+    static <K> ReentrantReadWriteLocks<K> reentrant(@SuppressWarnings("unused") Class<K> keyClass) {
         return reentrant();
     }
 
@@ -58,7 +54,7 @@ public class ReadWriteLocks<K, L extends ReadWriteLock> extends AbstractLocks<K,
      * @return {@code ReentrantReadWriteLocks} instance
      * @since 1.2.0
      */
-    public static <K> ReentrantReadWriteLocks<K> reentrant(boolean fair) {
+    static <K> ReentrantReadWriteLocks<K> reentrant(boolean fair) {
         return new ReentrantReadWriteLocks<>(fair);
     }
 
@@ -71,9 +67,17 @@ public class ReadWriteLocks<K, L extends ReadWriteLock> extends AbstractLocks<K,
      * @return {@code ReentrantReadWriteLocks} instance
      * @since 1.2.0
      */
-    public static <K> ReentrantReadWriteLocks<K> reentrant(boolean fair, @SuppressWarnings("unused") Class<K> keyClass) {
+    static <K> ReentrantReadWriteLocks<K> reentrant(boolean fair, @SuppressWarnings("unused") Class<K> keyClass) {
         return reentrant(fair);
     }
+
+    /**
+     * Returns a lock for the supplied key. There will be at most one lock per key at any given time.
+     *
+     * @param key key
+     * @return lock
+     */
+    L get(K key);
 
     /**
      * Return a {@code ReadWriteLock} with its {@link ReadWriteLock#readLock()} already locked using {@link Lock#lock()}.
@@ -81,11 +85,7 @@ public class ReadWriteLocks<K, L extends ReadWriteLock> extends AbstractLocks<K,
      * @param key key
      * @return already read locked lock
      */
-    public L readLock(K key) {
-        final var lock = get(key);
-        lock.readLock().lock();
-        return lock;
-    }
+    L readLock(K key);
 
     /**
      * Return a {@code ReadWriteLock} with its {@link ReadWriteLock#writeLock()} already locked using {@link Lock#lock()}.
@@ -93,10 +93,13 @@ public class ReadWriteLocks<K, L extends ReadWriteLock> extends AbstractLocks<K,
      * @param key key
      * @return already write locked lock
      */
-    public L writeLock(K key) {
-        final var lock = get(key);
-        lock.writeLock().lock();
-        return lock;
-    }
+    L writeLock(K key);
+
+    /**
+     * Returns the current number of locks managed by this instance.
+     *
+     * @return number of locks
+     */
+    int size();
 
 }

--- a/src/main/java/net/dapete/locks/ReadWriteLocksImpl.java
+++ b/src/main/java/net/dapete/locks/ReadWriteLocksImpl.java
@@ -1,0 +1,26 @@
+package net.dapete.locks;
+
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.function.Supplier;
+
+class ReadWriteLocksImpl<K, L extends ReadWriteLock> extends AbstractLocks<K, L> implements ReadWriteLocks<K, L> {
+
+    ReadWriteLocksImpl(Supplier<L> lockSupplier) {
+        super(lockSupplier);
+    }
+
+    @Override
+    public L readLock(K key) {
+        final var lock = get(key);
+        lock.readLock().lock();
+        return lock;
+    }
+
+    @Override
+    public L writeLock(K key) {
+        final var lock = get(key);
+        lock.writeLock().lock();
+        return lock;
+    }
+
+}

--- a/src/main/java/net/dapete/locks/ReadWriteLocksImpl.java
+++ b/src/main/java/net/dapete/locks/ReadWriteLocksImpl.java
@@ -10,14 +10,14 @@ class ReadWriteLocksImpl<K, L extends ReadWriteLock> extends AbstractLocks<K, L>
     }
 
     @Override
-    public L readLock(K key) {
+    public final L readLock(K key) {
         final var lock = get(key);
         lock.readLock().lock();
         return lock;
     }
 
     @Override
-    public L writeLock(K key) {
+    public final L writeLock(K key) {
         final var lock = get(key);
         lock.writeLock().lock();
         return lock;

--- a/src/main/java/net/dapete/locks/ReentrantLocks.java
+++ b/src/main/java/net/dapete/locks/ReentrantLocks.java
@@ -9,7 +9,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @param <K> type of key
  */
-public class ReentrantLocks<K> extends LocksImpl<K, ReentrantLock> {
+ public final class ReentrantLocks<K> extends LocksImpl<K, ReentrantLock> {
 
     ReentrantLocks() {
         super(ReentrantLock::new);

--- a/src/main/java/net/dapete/locks/ReentrantLocks.java
+++ b/src/main/java/net/dapete/locks/ReentrantLocks.java
@@ -9,7 +9,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @param <K> type of key
  */
-public class ReentrantLocks<K> extends Locks<K, ReentrantLock> {
+public class ReentrantLocks<K> extends LocksImpl<K, ReentrantLock> {
 
     ReentrantLocks() {
         super(ReentrantLock::new);

--- a/src/main/java/net/dapete/locks/ReentrantReadWriteLocks.java
+++ b/src/main/java/net/dapete/locks/ReentrantReadWriteLocks.java
@@ -9,7 +9,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *
  * @param <K> type of key
  */
-public class ReentrantReadWriteLocks<K> extends ReadWriteLocksImpl<K, ReentrantReadWriteLock> {
+public final class ReentrantReadWriteLocks<K> extends ReadWriteLocksImpl<K, ReentrantReadWriteLock> {
 
     ReentrantReadWriteLocks() {
         super(ReentrantReadWriteLock::new);

--- a/src/main/java/net/dapete/locks/ReentrantReadWriteLocks.java
+++ b/src/main/java/net/dapete/locks/ReentrantReadWriteLocks.java
@@ -9,7 +9,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  *
  * @param <K> type of key
  */
-public class ReentrantReadWriteLocks<K> extends ReadWriteLocks<K, ReentrantReadWriteLock> {
+public class ReentrantReadWriteLocks<K> extends ReadWriteLocksImpl<K, ReentrantReadWriteLock> {
 
     ReentrantReadWriteLocks() {
         super(ReentrantReadWriteLock::new);

--- a/src/test/java/net/dapete/locks/LocksTest.java
+++ b/src/test/java/net/dapete/locks/LocksTest.java
@@ -4,8 +4,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;


### PR DESCRIPTION
Refactoring:
* Increase minor version to 1.3 before breaking changes
* Convert `Locks` and `ReadWriteLocks` to interfaces
* Make classes and methods final if possible

Using interfaces fixes an inconsistency in the API. It was possible to call `ReentrantLocks.withSupplier(...)`, which made no sense - this method should only be accessible as `Locks.withSupplier(...)`. `static` methods in interfaces can not be called on classes implementing them this way, so this is solved by using an interface here.