### PR TITLE
Use snippet in JavaDoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This library contains classes for key-based locking, as in a way to obtain `Lock`s or `ReadWriteLock`s which are identified by a key.
 
-Requires JDK 11 or later.
+Requires JRE 11 or later to use and JDK 18 or later to build.
 
 ## Example
 

--- a/pom.xml
+++ b/pom.xml
@@ -142,6 +142,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.6.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-gpg-plugin</artifactId>
                     <version>3.2.8</version>
                 </plugin>
@@ -213,6 +218,29 @@
             </plugins>
         </pluginManagement>
         <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>enforce-versions</id>
+                        <goals>
+                            <goal>enforce</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <requireJavaVersion>
+                                    <version>18</version>
+                                    <message>
+                                        This project uses JEP 413 (Code Snippets in Java API Documentation) in its
+                                        JavaDoc documentation, which is only available in JDK 18+.
+                                    </message>
+                                </requireJavaVersion>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/net/dapete/locks/package-info.java
+++ b/src/main/java/net/dapete/locks/package-info.java
@@ -72,8 +72,8 @@
  *     Following the same pattern as described in the JDK documentation for {@link java.util.concurrent.locks.Lock Lock}, using {@link net.dapete.locks.Locks}
  *     should look similar to this:
  * </p>
- * <pre>
- * {@code public class LocksExample {
+ * {@snippet :
+ * public class LocksExample {
  *
  *     private final ReentrantLocks<String> locks = Locks.reentrant();
  *
@@ -86,8 +86,8 @@
  *         }
  *     }
  *
- * }}
- * </pre>
+ * }
+ * }
  * <p>
  *     It is important to keep the lock in a local variable while it is being used. It is stored in a {@link java.lang.ref.WeakReference WeakReference}, so it
  *     could be removed by the garbage collector at any time while it is not referenced.
@@ -96,15 +96,15 @@
  *     An alternative way which may be useful if the lock is not always used or used multiple times would be to split the {@code final var lock = …} line
  *     in two:
  * </p>
- * <pre>
- * {@code final var lock = locks.get(url);
- * lock.lock();}
- * </pre>
+ * {@snippet :
+ * final var lock = locks.get(url);
+ * lock.lock();
+ * }
  * <p>
  *     For {@link net.dapete.locks.ReadWriteLocks} it is similar to the first example:
  * </p>
- * <pre>
- * {@code public class ReadWriteLocksExample {
+ * {@snippet :
+ * public class ReadWriteLocksExample {
  *
  *     private final ReentrantReadWriteLocks<String> locks = ReadWriteLocks.reentrant();
  *
@@ -126,8 +126,8 @@
  *         }
  *     }
  *
- * }}
- * </pre>
+ * }
+ * }
  * <p>
  *     Again the {@code final var lock = …} lines could be split, which may be useful if both read and write locks are used in the method.
  * </p>


### PR DESCRIPTION
This means JDK 18 or later is required to build, just for the JavaDoc. Add `maven-enforcer-plugin` to check for this.